### PR TITLE
ブラウザで指定のページを開いている限りカウントアップする数字を表示する処理を実装

### DIFF
--- a/src/main/java/oit/is/team0805/lec05/Lec05Application.java
+++ b/src/main/java/oit/is/team0805/lec05/Lec05Application.java
@@ -2,12 +2,16 @@ package oit.is.team0805.lec05;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
+@EnableScheduling
 @SpringBootApplication
 public class Lec05Application {
 
-	public static void main(String[] args) {
-		SpringApplication.run(Lec05Application.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(Lec05Application.class, args);
+  }
 
 }

--- a/src/main/java/oit/is/team0805/lec05/controller/Sample56Controller.java
+++ b/src/main/java/oit/is/team0805/lec05/controller/Sample56Controller.java
@@ -1,0 +1,54 @@
+package oit.is.team0805.lec05.controller;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import oit.is.team0805.lec05.service.AsyncCountFruit56;
+
+/**
+ * /sample56へのリクエストを扱うクラス
+ */
+@Controller
+@RequestMapping("/sample56")
+public class Sample56Controller {
+
+  // コンソールに出力したいログ情報を簡単に使えるようにするためのクラス
+  // どこのクラスでもgetLogger内のクラス名を替えるだけで使える
+  // 似たようなロガークラスが大量にあるので import org.slf4j.Logger; を間違えないようにすること
+  private final Logger logger = LoggerFactory.getLogger(Sample56Controller.class);
+
+  @Autowired
+  private AsyncCountFruit56 ac56;
+
+  /**
+   * 数字をカウントアップしながらpushしつづけるメソッド
+   *
+   * @return
+   */
+  @GetMapping("step1")
+  public SseEmitter pushCount() {
+    // infoレベルでログを出力する
+    logger.info("pushCount");
+
+    // finalは初期化したあとに再代入が行われない変数につける（意図しない再代入を防ぐ）
+    final SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);//
+    // 引数にLongの最大値をTimeoutとして指定する
+
+    try {
+      this.ac56.count(emitter);
+    } catch (IOException e) {
+      // 例外の名前とメッセージだけ表示する
+      logger.warn("Exception:" + e.getClass().getName() + ":" + e.getMessage());
+      emitter.complete();
+    }
+    return emitter;
+  }
+
+}

--- a/src/main/java/oit/is/team0805/lec05/service/AsyncCountFruit56.java
+++ b/src/main/java/oit/is/team0805/lec05/service/AsyncCountFruit56.java
@@ -1,0 +1,60 @@
+package oit.is.team0805.lec05.service;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import oit.is.team0805.lec05.model.Fruit;
+
+@Service
+public class AsyncCountFruit56 {
+  int count = 1;
+  private final Logger logger = LoggerFactory.getLogger(AsyncCountFruit56.class);
+
+  @Async
+  public void count(SseEmitter emitter) throws IOException {
+    logger.info("count start");
+    try {
+      while (true) {// 無限ループ
+        logger.info("send:" + count);
+        // sendによってcountがブラウザにpushされる
+        emitter.send(count);
+        count++;
+        // 1秒STOP
+        TimeUnit.SECONDS.sleep(1);
+      }
+    } catch (InterruptedException e) {
+      // 例外の名前とメッセージだけ表示する
+      logger.warn("Exception:" + e.getClass().getName() + ":" + e.getMessage());
+    }
+  }
+
+  @Async
+  public void pushFruit(SseEmitter emitter) {
+    logger.info("pushFruit start");
+    Fruit fruit = new Fruit();
+    fruit.setName("桃");
+    fruit.setPrice(300);
+    // 10回sendすると一度接続を終了する．その後ブラウザを開いていればブラウザから自動的に再接続されてまた10回sendされる（以降繰り返し）
+    for (int i = 0; i < 10; i++) {
+      try {
+        logger.info("send(fruit)");
+        TimeUnit.SECONDS.sleep(1);// 1秒STOP
+        // fruitのJSONオブジェクトがクライアントに送付される
+        emitter.send(fruit);
+
+      } catch (Exception e) {
+        // 例外の名前とメッセージだけ表示する
+        logger.warn("Exception:" + e.getClass().getName() + ":" + e.getMessage());
+        // 例外が発生したらカウントとsendを終了する
+        break;
+      }
+    }
+    emitter.complete();// emitterの後始末．明示的にブラウザとの接続を一度切る．
+  }
+}

--- a/src/main/resources/static/sample56-1.html
+++ b/src/main/resources/static/sample56-1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>SpringBoot Sample5-6-1</title>
+  <script>
+    window.onload = function () {
+
+      var sse = new EventSource('/sample56/step1');
+      sse.onmessage = function (event) {
+        console.log(event.data);
+        document.getElementById("p1").textContent = event.data;
+      }
+    }
+  </script>
+</head>
+
+<body>
+  <p id="p1"></p>
+</body>
+
+</html>


### PR DESCRIPTION
/sample56-1.html にアクセスすると数字が1秒毎にカウントアップしていく
ブラウザで表示していない間はカウントアップしない
ブラウザを閉じてからまた開くと開く前の続きの数字からカウントアップする
複数のブラウザやタブで表示するとその数だけ一度に数字がカウントアップする
ユーザ認証を必要としない