### PR TITLE
果物の購入と非同期処理の実装

### DIFF
--- a/src/main/java/oit/is/team0805/lec05/controller/Sample57Controller.java
+++ b/src/main/java/oit/is/team0805/lec05/controller/Sample57Controller.java
@@ -55,4 +55,11 @@ public class Sample57Controller {
 
     return "sample57.html";
   }
+
+  @GetMapping("step9")
+  public SseEmitter sample59() {
+    final SseEmitter sseEmitter = new SseEmitter();
+    this.shop57.asyncShowFruitsList(sseEmitter);
+    return sseEmitter;
+  }
 }

--- a/src/main/java/oit/is/team0805/lec05/controller/Sample57Controller.java
+++ b/src/main/java/oit/is/team0805/lec05/controller/Sample57Controller.java
@@ -41,4 +41,18 @@ public class Sample57Controller {
     model.addAttribute("fruits7", fruits7);
     return "sample57.html";
   }
+
+  @GetMapping("step8")
+  @Transactional
+  public String sample58(@RequestParam Integer id, ModelMap model) {
+    // 選択したフルーツを削除し，削除対象のフルーツをmodelに登録
+    final Fruit fruit8 = this.shop57.syncBuyFruits(id);
+    model.addAttribute("fruit8", fruit8);
+
+    // 残りのフルーツリストを取得してmodelに登録
+    final ArrayList<Fruit> fruits7 = shop57.syncShowFruitsList();
+    model.addAttribute("fruits7", fruits7);
+
+    return "sample57.html";
+  }
 }


### PR DESCRIPTION
Sample5-7を実行後，[購入]リンクをクリックすると，対象の果物がDBのテーブル及びHTML上のテーブルから削除され，あるユーザが開いている果物一覧ページで購入処理を行うと，DBから対象の果物が削除される．このとき，同時に同じページを開いている別のユーザに対して，表示している果物一覧をサーバからの非同期メッセージにより更新する
